### PR TITLE
Changed model to model_type

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,8 +75,19 @@ Error::log()
     ->withDetails('Extra information of this log!')
     ->withThrowable($exception)
     ->withChannel('slack')
+    ->withModel($model)
     ->save();
 ```
+
+### Method FromThrowable
+
+You may also use the method `fromThrowable`. This function accepts a `Throwable` which automatically sets the following
+extra attributes compared to `withThrowable`:
+
+- withDetails
+- withCode
+
+It is still possible to override these values when chaining them after the throwable.
 
 ## License
 

--- a/database/migrations/2022_01_12_143000_update_model_field_to_model_type.php
+++ b/database/migrations/2022_01_12_143000_update_model_field_to_model_type.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class UpdateModelFieldToModelType extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('laravel_errors', function (Blueprint $table): void {
+            $table->renameColumn('model', 'model_type');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('laravel_errors', function (Blueprint $table): void {
+            $table->renameColumn('model_type', 'model');
+        });
+    }
+}

--- a/src/Models/Error.php
+++ b/src/Models/Error.php
@@ -18,7 +18,7 @@ use Illuminate\Support\Str;
  * @property ?string $trace
  * @property ?string $vendor_trace
  * @property ?string $channel
- * @property ?string $model
+ * @property ?string $model_type
  * @property ?int $model_id
  */
 class Error extends Model
@@ -83,9 +83,11 @@ class Error extends Model
         return $this;
     }
 
-    public function withDetails(string $details = null): self
+    public function withDetails(string|array $details = null): self
     {
-        $this->details = $details;
+        $this->details = is_string($details)
+            ? $details
+            : json_encode($details, JSON_PRETTY_PRINT);
 
         return $this;
     }
@@ -93,7 +95,7 @@ class Error extends Model
     public function fromThrowable(Throwable $throwable): self
     {
         return $this
-            ->withMessage($throwable->getMessage())
+            ->withDetails($throwable->getMessage())
             ->withCode($throwable->getCode())
             ->withThrowable($throwable);
     }
@@ -130,7 +132,7 @@ class Error extends Model
 
     public function withModel(Model $model): self
     {
-        $this->model = get_class($model);
+        $this->model_type = get_class($model);
         $this->model_id = $model->id;
 
         return $this;


### PR DESCRIPTION
- Changed the `model` field to `model_type` to be more compliant with Laravel.
- Throwable messages will be saved into the `details` column to prevent long messages in the overview.
- Details can be an array which will be automatically converted to JSON.